### PR TITLE
test: add global @testing-library/jest-dom import to not repeat it in…

### DIFF
--- a/src/__tests__/TodoForm.spec.tsx
+++ b/src/__tests__/TodoForm.spec.tsx
@@ -1,4 +1,3 @@
-import '@testing-library/jest-dom';
 import { render, screen, fireEvent } from "@testing-library/react"
 import TodoForm from '../components/TodoForm';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "types": ["jest", "@testing-library/jest-dom"]
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]


### PR DESCRIPTION
Solve the repeat error with `import "@testing-library/jest-dom"` in test files. Now you don't need to include it in every test file.